### PR TITLE
Feature/#34 me auth endpoint

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -20,4 +20,10 @@ export class AuthController {
   async logout(@UserObj() user: User, @Res() res: Response) {
     return this.authService.logout(user, res);
   }
+
+  @Get('/me')
+  @UseGuards(AuthGuard('jwt'))
+  async showUser(@UserObj() user: User, @Res() res: Response) {
+    return this.authService.checkActiveUser(user, res);
+  }
 }

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -81,6 +81,7 @@ export class AuthService {
       fullName: user.fullName,
       role: user.role,
       ghUsername: user.githubUsername,
+      maxReservedStudents: user.maxReservedStudents,
     });
   }
 }

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -72,4 +72,15 @@ export class AuthService {
       return res.json({ error: e.message });
     }
   }
+
+  async checkActiveUser(user: User, res: Response) {
+    return res.json({
+      email: user.email,
+      firstName: user.firstName,
+      lastName: user.lastName,
+      fullName: user.fullName,
+      role: user.role,
+      ghUsername: user.githubUsername,
+    });
+  }
 }

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -6,6 +6,7 @@ import { v4 as uuid } from 'uuid';
 import { sign } from 'jsonwebtoken';
 import { JwtPayload } from './jwt.strategy';
 import { User } from '../student/entities/user.entity';
+import { AuthUser } from '../../types';
 
 @Injectable()
 export class AuthService {
@@ -82,6 +83,6 @@ export class AuthService {
       role: user.role,
       ghUsername: user.githubUsername,
       maxReservedStudents: user.maxReservedStudents,
-    });
+    } as AuthUser);
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,7 +4,10 @@ import { AppModule } from './app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
-  app.enableCors();
+  app.enableCors({
+    origin: 'http://localhost:3000',
+    credentials: true,
+  });
   app.enableShutdownHooks();
   app.use(cookieParser());
   await app.listen(3001);

--- a/src/student/entities/user.entity.ts
+++ b/src/student/entities/user.entity.ts
@@ -22,7 +22,7 @@ export class User extends BaseEntity {
     type: 'text',
     nullable: true,
   })
-  password: string;
+  password: string | null;
 
   @Column({
     width: 15,
@@ -36,21 +36,21 @@ export class User extends BaseEntity {
     type: 'text',
     nullable: true,
   })
-  firstName: true;
+  firstName: string | null;
 
   @Column({
     width: 128,
     type: 'text',
     nullable: true,
   })
-  lastName: string;
+  lastName: string | null;
 
   @Column({
     width: 39,
     type: 'text',
     nullable: true,
   })
-  githubUsername: string;
+  githubUsername: string | null;
 
   @Column({
     width: 2000,
@@ -64,7 +64,7 @@ export class User extends BaseEntity {
     type: 'text',
     nullable: true,
   })
-  projectUrls: string;
+  projectUrls: string | null;
 
   @Column({
     width: 250,
@@ -78,7 +78,7 @@ export class User extends BaseEntity {
     enum: ExpectedTypeWork,
     nullable: true,
   })
-  expectedTypeWork: ExpectedTypeWork;
+  expectedTypeWork: ExpectedTypeWork | null;
 
   @Column({
     width: 189,
@@ -92,7 +92,7 @@ export class User extends BaseEntity {
     enum: ExpectedContractType,
     nullable: true,
   })
-  expectedContractType: ExpectedContractType;
+  expectedContractType: ExpectedContractType | null;
 
   @Column({
     width: 5,
@@ -113,7 +113,7 @@ export class User extends BaseEntity {
     type: 'tinyint',
     nullable: true,
   })
-  monthsOfCommercialExp: number;
+  monthsOfCommercialExp: number | null;
 
   @Column({
     width: 2000,
@@ -156,19 +156,19 @@ export class User extends BaseEntity {
     type: 'text',
     nullable: true,
   })
-  fullName: string;
+  fullName: string | null;
 
   @Column({
     width: 160,
     type: 'text',
     nullable: true,
   })
-  company: string;
+  company: string | null;
 
   @Column({
     width: 3,
     type: 'tinyint',
     nullable: true,
   })
-  maxReservedStudents: number;
+  maxReservedStudents: number | null;
 }

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,1 +1,2 @@
 export * from './example';
+export * from './user';

--- a/types/user/index.ts
+++ b/types/user/index.ts
@@ -1,0 +1,1 @@
+export * from './user';

--- a/types/user/user.ts
+++ b/types/user/user.ts
@@ -1,0 +1,11 @@
+import { Role } from '../../src/student/interfaces/user';
+
+export interface AuthUser {
+  email: string;
+  firstName: string | null;
+  lastName: string | null;
+  fullName: string | null;
+  role: Role;
+  ghUsername: string | null;
+  maxReservedStudents: number | null;
+}


### PR DESCRIPTION
Added /me endpoint in auth controller that returns the active user data. It's protected by AuthGuard so returns 401 Unauthorized when the user is not logged in or have invalid token.
The endpoint can be used on frontend to retrieve logged in user data and to check if the user is still logged in and have a valid jwt
EDIT: Fixed User entity - firstName was boolean instead of a string type!
EDIT2: added options to CORS policy - origin is required with credentials 'included' on frontend fetch